### PR TITLE
mineBlocks set too low for USDC interest to accrue

### DIFF
--- a/test/behavior/compound-strategy.js
+++ b/test/behavior/compound-strategy.js
@@ -267,7 +267,7 @@ function shouldBehaveLikeStrategy(poolName, collateralName, accounts) {
 
         strategy = await this.newStrategy.new(controller.address, pool.address)
         await controller.updateStrategy(pool.address, strategy.address)
-        await mineBlocks(25)
+        await mineBlocks(200)
         await providerToken.exchangeRateCurrent()
 
         // Deposit and rebalance with new strategy but before migrateIn


### PR DESCRIPTION
Share price wasn't increasing in tests because "mineBlocks" was set too low and USDC is only 6 decimals causing some precision loss using just 25 blocks.